### PR TITLE
Use a custom retainAll method for usedDeclaredDependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <artifactId>maven-dependency-analyzer</artifactId>
   <packaging>jar</packaging>
-  <version>1.11.2-SNAPSHOT</version>
+  <version>1.11.2-hubspot-SNAPSHOT</version>
 
   <name>Apache Maven Dependency Analyzer</name>
   <description>
@@ -60,7 +60,7 @@
 
   <properties>
     <mavenVersion>2.0.5</mavenVersion>
-    <javaVersion>7</javaVersion>
+    <javaVersion>8</javaVersion>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
`retainAll` seems to not work for the SNAPSHOT `Artifact` objects we have here. I copied the implementation of `removeAll` below in order to fix this. Previously, it didn't really matter what this said, because we just ignored it. But now, we care about everything that's considered used for our migrations.

Does anyone see any potential problems here?

@jhaber @kmclarnon @Xcelled 