### PR TITLE
apply hubspot changes to rebased master

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -79,8 +79,10 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             Set<Artifact> testOnlyArtifacts = removeAll(testArtifacts, mainUsedArtifacts);
 
             Set<Artifact> declaredArtifacts = buildDeclaredArtifacts(project);
+            Map<Artifact, Set<DependencyUsage>> usedDeclaredArtifactsWithClasses = new LinkedHashMap<>(usedArtifacts);
             Set<Artifact> usedDeclaredArtifacts = new LinkedHashSet<>(declaredArtifacts);
             usedDeclaredArtifacts.retainAll(usedArtifacts.keySet());
+            usedDeclaredArtifactsWithClasses.keySet().retainAll(usedDeclaredArtifacts);
 
             Map<Artifact, Set<DependencyUsage>> usedUndeclaredArtifactsWithClasses = new LinkedHashMap<>(usedArtifacts);
             Set<Artifact> usedUndeclaredArtifacts =
@@ -93,7 +95,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             Set<Artifact> testArtifactsWithNonTestScope = getTestArtifactsWithNonTestScope(testOnlyArtifacts);
 
             return new ProjectDependencyAnalysis(
-                    usedDeclaredArtifacts, usedUndeclaredArtifactsWithClasses,
+                    usedDeclaredArtifactsWithClasses, usedUndeclaredArtifactsWithClasses,
                     unusedDeclaredArtifacts, testArtifactsWithNonTestScope);
         } catch (IOException exception) {
             throw new ProjectDependencyAnalyzerException("Cannot analyze dependencies", exception);
@@ -141,7 +143,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         return nonTestScopeArtifacts;
     }
 
-    private Map<Artifact, Set<String>> buildArtifactClassMap(MavenProject project) throws IOException {
+    protected Map<Artifact, Set<String>> buildArtifactClassMap(MavenProject project) throws IOException {
         Map<Artifact, Set<String>> artifactClassMap = new LinkedHashMap<>();
 
         Set<Artifact> dependencyArtifacts = project.getArtifacts();

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyAnalyzer.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.dependency.analyzer;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Gets the set of classes referenced by a library given either as a jar file or an exploded directory.
@@ -36,5 +37,19 @@ public interface DependencyAnalyzer {
      * @return the set of class names referenced by the library
      * @throws IOException if an error occurs reading a JAR or .class file
      */
-    Set<String> analyze(URL url) throws IOException;
+    default Set<String> analyze(URL url) throws IOException {
+        return analyzeUsages(url).stream()
+                .map(DependencyUsage::getDependencyClass)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * <p>analyzeUsages.</p>
+     *
+     * @param url the JAR file or directory to analyze
+     * @return the set of class names referenced by the library, paired with the
+     * classes declaring those references.
+     * @throws IOException if an error occurs reading a JAR or .class file
+     */
+    Set<DependencyUsage> analyzeUsages(URL url) throws IOException;
 }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyUsage.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyUsage.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.dependency.analyzer;
+
+/**
+ * Usage of a dependency class by a project class.
+ *
+ * @author <a href="mailto:hijon89@gmail.com">Jonathan Haber</a>
+ */
+public class DependencyUsage {
+
+    private final String dependencyClass;
+
+    private final String usedBy;
+
+    public DependencyUsage(String dependencyClass, String usedBy) {
+        this.dependencyClass = dependencyClass;
+        this.usedBy = usedBy;
+    }
+
+    /**
+     * @return the dependency class used by the project class
+     */
+    public String getDependencyClass() {
+        return dependencyClass;
+    }
+
+    /**
+     * @return the project class using the dependency class
+     */
+    public String getUsedBy() {
+        return usedBy;
+    }
+
+    /*
+     * @see java.lang.Object#hashCode()
+     */
+    public int hashCode() {
+        int hashCode = dependencyClass.hashCode();
+        hashCode = (hashCode * 37) + usedBy.hashCode();
+
+        return hashCode;
+    }
+
+    /*
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    public boolean equals(Object object) {
+        if (object instanceof DependencyUsage) {
+            DependencyUsage usage = (DependencyUsage) object;
+
+            return getDependencyClass().equals(usage.getDependencyClass())
+                    && getUsedBy().equals(usage.getUsedBy());
+        }
+
+        return false;
+    }
+
+    /*
+     * @see java.lang.Object#toString()
+     */
+    public String toString() {
+        StringBuilder buffer = new StringBuilder();
+
+        buffer.append("dependencyClass=").append(getDependencyClass());
+        buffer.append(",");
+        buffer.append("usedBy=").append(getUsedBy());
+
+        buffer.insert(0, "[");
+        buffer.insert(0, getClass().getName());
+
+        buffer.append("]");
+
+        return buffer.toString();
+    }
+}

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ASMDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ASMDependencyAnalyzer.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.apache.maven.shared.dependency.analyzer.ClassFileVisitorUtils;
 import org.apache.maven.shared.dependency.analyzer.DependencyAnalyzer;
+import org.apache.maven.shared.dependency.analyzer.DependencyUsage;
 
 /**
  * ASMDependencyAnalyzer
@@ -36,13 +37,13 @@ import org.apache.maven.shared.dependency.analyzer.DependencyAnalyzer;
 @Named
 @Singleton
 public class ASMDependencyAnalyzer implements DependencyAnalyzer {
-    /** {@inheritDoc} */
+
     @Override
-    public Set<String> analyze(URL url) throws IOException {
+    public Set<DependencyUsage> analyzeUsages(URL url) throws IOException {
         DependencyClassFileVisitor visitor = new DependencyClassFileVisitor();
 
         ClassFileVisitorUtils.accept(url, visitor);
 
-        return visitor.getDependencies();
+        return visitor.getDependencyUsages();
     }
 }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultAnnotationVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultAnnotationVisitor.java
@@ -31,39 +31,50 @@ import org.objectweb.asm.Type;
 public class DefaultAnnotationVisitor extends AnnotationVisitor {
     private final ResultCollector resultCollector;
 
+    private final String usedByClass;
+
     /**
      * <p>Constructor for DefaultAnnotationVisitor.</p>
      *
      * @param resultCollector a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
      */
-    public DefaultAnnotationVisitor(ResultCollector resultCollector) {
+    public DefaultAnnotationVisitor(ResultCollector resultCollector, String usedByClass) {
         super(Opcodes.ASM9);
         this.resultCollector = resultCollector;
+        this.usedByClass = usedByClass;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void visit(final String name, final Object value) {
         if (value instanceof Type) {
-            resultCollector.addType((Type) value);
+            resultCollector.addType(usedByClass, (Type) value);
         }
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void visitEnum(final String name, final String desc, final String value) {
-        resultCollector.addDesc(desc);
+        resultCollector.addDesc(usedByClass, desc);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public AnnotationVisitor visitAnnotation(final String name, final String desc) {
-        resultCollector.addDesc(desc);
+        resultCollector.addDesc(usedByClass, desc);
 
         return this;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public AnnotationVisitor visitArray(final String name) {
         return this;

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultFieldVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultFieldVisitor.java
@@ -33,22 +33,28 @@ public class DefaultFieldVisitor extends FieldVisitor {
 
     private final ResultCollector resultCollector;
 
+    private final String usedByClass;
+
     /**
      * <p>Constructor for DefaultFieldVisitor.</p>
      *
      * @param annotationVisitor a {@link org.objectweb.asm.AnnotationVisitor} object.
-     * @param resultCollector a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
+     * @param resultCollector   a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
      */
-    public DefaultFieldVisitor(AnnotationVisitor annotationVisitor, ResultCollector resultCollector) {
+    public DefaultFieldVisitor(
+            AnnotationVisitor annotationVisitor, ResultCollector resultCollector, String usedByClass) {
         super(Opcodes.ASM9);
         this.annotationVisitor = annotationVisitor;
         this.resultCollector = resultCollector;
+        this.usedByClass = usedByClass;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public AnnotationVisitor visitAnnotation(final String desc, final boolean visible) {
-        resultCollector.addDesc(desc);
+        resultCollector.addDesc(usedByClass, desc);
 
         return annotationVisitor;
     }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultSignatureVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultSignatureVisitor.java
@@ -29,26 +29,32 @@ import org.objectweb.asm.signature.SignatureVisitor;
  */
 public class DefaultSignatureVisitor extends SignatureVisitor {
     private final ResultCollector resultCollector;
+    private final String usedByClass;
 
     /**
      * <p>Constructor for DefaultSignatureVisitor.</p>
      *
      * @param resultCollector a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
      */
-    public DefaultSignatureVisitor(ResultCollector resultCollector) {
+    public DefaultSignatureVisitor(ResultCollector resultCollector, String usedByClass) {
         super(Opcodes.ASM9);
         this.resultCollector = resultCollector;
+        this.usedByClass = usedByClass;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void visitClassType(final String name) {
-        resultCollector.addName(name);
+        resultCollector.addName(usedByClass, name);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void visitInnerClassType(final String name) {
-        resultCollector.addName(name);
+        resultCollector.addName(usedByClass, name);
     }
 }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
@@ -20,7 +20,9 @@ package org.apache.maven.shared.dependency.analyzer.asm;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.apache.maven.shared.dependency.analyzer.DependencyUsage;
 import org.objectweb.asm.Type;
 
 /**
@@ -30,7 +32,7 @@ import org.objectweb.asm.Type;
  */
 public class ResultCollector {
 
-    private final Set<String> classes = new HashSet<>();
+    private final Set<DependencyUsage> classUsages = new HashSet<>();
 
     /**
      * <p>getDependencies.</p>
@@ -38,7 +40,18 @@ public class ResultCollector {
      * @return a {@link java.util.Set} object.
      */
     public Set<String> getDependencies() {
-        return classes;
+        return getDependencyUsages().stream()
+                .map(DependencyUsage::getDependencyClass)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * <p>getDependencyUsages.</p>
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    public Set<DependencyUsage> getDependencyUsages() {
+        return classUsages;
     }
 
     /**
@@ -46,7 +59,7 @@ public class ResultCollector {
      *
      * @param name a {@link java.lang.String} object.
      */
-    public void addName(String name) {
+    public void addName(final String usedByClass, String name) {
         if (name == null) {
             return;
         }
@@ -65,21 +78,21 @@ public class ResultCollector {
         }
 
         // decode internal representation
-        add(name.replace('/', '.'));
+        add(usedByClass, name.replace('/', '.'));
     }
 
-    void addDesc(final String desc) {
-        addType(Type.getType(desc));
+    void addDesc(final String usedByClass, final String desc) {
+        addType(usedByClass, Type.getType(desc));
     }
 
-    void addType(final Type t) {
+    void addType(final String usedByClass, final Type t) {
         switch (t.getSort()) {
             case Type.ARRAY:
-                addType(t.getElementType());
+                addType(usedByClass, t.getElementType());
                 break;
 
             case Type.OBJECT:
-                addName(t.getClassName());
+                addName(usedByClass, t.getClassName());
                 break;
 
             default:
@@ -91,30 +104,30 @@ public class ResultCollector {
      *
      * @param name a {@link java.lang.String} object.
      */
-    public void add(String name) {
+    public void add(final String usedByClass, final String name) {
         // inner classes have equivalent compilation requirement as container class
         if (name.indexOf('$') < 0) {
-            classes.add(name);
+            classUsages.add(new DependencyUsage(name, usedByClass));
         }
     }
 
-    void addNames(final String[] names) {
+    void addNames(final String usedByClass, final String[] names) {
         if (names == null) {
             return;
         }
 
         for (String name : names) {
-            addName(name);
+            addName(usedByClass, name);
         }
     }
 
-    void addMethodDesc(final String desc) {
-        addType(Type.getReturnType(desc));
+    void addMethodDesc(final String usedByClass, final String desc) {
+        addType(usedByClass, Type.getReturnType(desc));
 
         Type[] types = Type.getArgumentTypes(desc);
 
         for (Type type : types) {
-            addType(type);
+            addType(usedByClass, type);
         }
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyVisitorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyVisitorTest.java
@@ -20,13 +20,7 @@ package org.apache.maven.shared.dependency.analyzer.asm;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.Attribute;
-import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
+import org.objectweb.asm.*;
 import org.objectweb.asm.signature.SignatureVisitor;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,13 +35,16 @@ class DependencyVisitorTest {
     private DefaultClassVisitor visitor;
     private MethodVisitor mv;
 
+    private String usedByClass = "com.example.MyClass";
+
     @BeforeEach
     void setUp() {
-        AnnotationVisitor annotationVisitor = new DefaultAnnotationVisitor(resultCollector);
-        SignatureVisitor signatureVisitor = new DefaultSignatureVisitor(resultCollector);
-        FieldVisitor fieldVisitor = new DefaultFieldVisitor(annotationVisitor, resultCollector);
-        mv = new DefaultMethodVisitor(annotationVisitor, signatureVisitor, resultCollector);
-        visitor = new DefaultClassVisitor(signatureVisitor, annotationVisitor, fieldVisitor, mv, resultCollector);
+        AnnotationVisitor annotationVisitor = new DefaultAnnotationVisitor(resultCollector, usedByClass);
+        SignatureVisitor signatureVisitor = new DefaultSignatureVisitor(resultCollector, usedByClass);
+        FieldVisitor fieldVisitor = new DefaultFieldVisitor(annotationVisitor, resultCollector, usedByClass);
+        mv = new DefaultMethodVisitor(annotationVisitor, signatureVisitor, resultCollector, usedByClass);
+        visitor = new DefaultClassVisitor(
+                signatureVisitor, annotationVisitor, fieldVisitor, mv, resultCollector, usedByClass);
     }
 
     @Test


### PR DESCRIPTION
reapplies hubspot changes to the rebased master branch (at `1.13.3-SNAPSHOT`):

* DependencyUsage and tracking -- for both declared and undeclared usages
* changes visibility of `buildArtifactClassMap` from private to protected, for subclasses

Will force-push this onto `hubspot` branch once validated

@jhaber @kmclarnon @stevie400 @PtrTeixeira 